### PR TITLE
updates for polyglot-maven PR #182

### DIFF
--- a/kotlin/pom.kts
+++ b/kotlin/pom.kts
@@ -1,9 +1,8 @@
-project {
-    name = "Polyglot :: Kotlin"
+project("Polyglot :: Kotlin") {
+
     groupId = "io.takari.polyglot"
     artifactId = "regular-project"
     version = "0.3.3-SNAPSHOT"
-    packaging = jar
 
     val junitVersion = 4.12
     val kotlinVersion = "1.1.61"
@@ -11,11 +10,48 @@ project {
     dependencies {
         compile("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
         compile("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0")
-                .exclusions("org.jetbrains.kotlin:kotlin-stdlib")
+            .excluding("org.jetbrains.kotlin:kotlin-stdlib")
 
-        test(
-                "junit:junit:$junitVersion" exclusions "org.hamcrest:hamcrest-core",
-                "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
-        )
+        test("junit:junit:$junitVersion").excluding("org.hamcrest:hamcrest-core")
+        test("org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion")
+    }
+
+    build {
+        // Inline execution
+        execute(id = "hello", phase = "validate") {
+            log.info("Hello, from ${project.name}")
+        }
+
+        // External script execution
+        execute(id = "hello-script", phase = "validate", script = "src/build/scripts/Hello.kts")
+
+        sourceDirectory = "\${project.basedir}/src/main/kotlin"
+        testSourceDirectory = "\${project.basedir}/src/test/kotlin"
+
+        pluginManagement {
+            plugins {
+                plugin("org.jetbrains.kotlin:kotlin-maven-plugin:${kotlinVersion}") {
+                    executions {
+                        execution(id = "compile", goals = listOf("compile"))
+                        execution(id = "test-compile", goals = listOf("test-compile"))
+                    }
+                }
+                plugin("org.apache.maven.plugins:maven-jar-plugin") {
+                    configuration {
+                        "archive" {
+                            "index" to true
+                            "manifest" {
+                                "addClasspath" to true
+                                "mainClass" to "org.polyglot.kotlin.sample.Main"
+                            }
+                            "manifestEntries" {
+                                "mode" to "development"
+                                "url" to "\${project.url}"
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/kotlin/pom.kts
+++ b/kotlin/pom.kts
@@ -25,8 +25,8 @@ project("Polyglot :: Kotlin") {
         // External script execution
         execute(id = "hello-script", phase = "validate", script = "src/build/scripts/Hello.kts")
 
-        sourceDirectory = "\${project.basedir}/src/main/kotlin"
-        testSourceDirectory = "\${project.basedir}/src/test/kotlin"
+        sourceDirectory = "src/main/kotlin"
+        testSourceDirectory = "/src/test/kotlin"
 
         pluginManagement {
             plugins {

--- a/kotlin/src/build/scripts/Hello.kts
+++ b/kotlin/src/build/scripts/Hello.kts
@@ -1,0 +1,18 @@
+val project = bindings["project"] as org.apache.maven.project.MavenProject
+val session = bindings["session"] as org.apache.maven.execution.MavenSession
+val basedir = bindings["basedir"] as java.io.File
+val log = bindings["log"] as org.apache.maven.plugin.logging.Log
+val script = bindings["script"] as java.io.File
+val keys = bindings.keys as Collection<String>
+
+"""
+    ------------------------------------------------------------------------
+
+    HELLO ${project.name}!!!
+
+    Folder:   ${basedir}
+    Script:   .${script.path.substringAfter(basedir.path)}
+    Bindings: ${keys}
+
+    ------------------------------------------------------------------------
+""".trimIndent().lines().forEach { log.info(it) }

--- a/kotlin/src/build/scripts/Hello.kts
+++ b/kotlin/src/build/scripts/Hello.kts
@@ -1,18 +1,17 @@
 val project = bindings["project"] as org.apache.maven.project.MavenProject
 val session = bindings["session"] as org.apache.maven.execution.MavenSession
+val log     = bindings["log"]     as org.apache.maven.plugin.logging.Log
 val basedir = bindings["basedir"] as java.io.File
-val log = bindings["log"] as org.apache.maven.plugin.logging.Log
-val script = bindings["script"] as java.io.File
-val keys = bindings.keys as Collection<String>
+val script  = bindings["script"]  as java.io.File
 
 """
     ------------------------------------------------------------------------
 
-    HELLO ${project.name}!!!
+    Hello from ${project.name}
 
-    Folder:   ${basedir}
-    Script:   .${script.path.substringAfter(basedir.path)}
-    Bindings: ${keys}
+    Basedir:  ${basedir}
+    Script:   ${script.path.substringAfter("${basedir.path}/")}
+    Bindings: ${bindings.keys}
 
     ------------------------------------------------------------------------
 """.trimIndent().lines().forEach { log.info(it) }

--- a/runAll.sh
+++ b/runAll.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 set -e
 
+additionalArgs=$@
+
 polytest () {
   printf "=====================================================\n\n"
   printf "          Testing polyglot-$1 started. \n\n"
   printf "=====================================================\n\n"
   cd $1
-  mvn clean install -U
+  mvn $additionalArgs clean install -U
   printf "=====================================================\n\n"
   printf "          Testing polyglot-$1 completed. \n\n"
   printf "=====================================================\n\n"


### PR DESCRIPTION
This updates the kotlin example to demonstrate the updated DSL and execute features (See https://github.com/takari/polyglot-maven/pull/182). There were some DSL idioms and overloaded operations from the previous release that I chose not to bring forward because they were either non-idiomatic, their usage was confusing, or because they didn't appear to add value over their alternatives. That said, I'd be happy to add them back in if they are seen as necessary to preserve backward compatibility or if there is strong argument for their continued inclusion.